### PR TITLE
Adding dynamic airbrake

### DIFF
--- a/Nasal/f16_controls.nas
+++ b/Nasal/f16_controls.nas
@@ -1,0 +1,42 @@
+print("*** LOADING f16_controls.nas ... ***");
+################################################################################
+#
+#                        f16's CONTROLS SETTINGS
+#
+################################################################################
+# The goal is to overwrite some controls in order of put it on a stick (and
+# even perhaps multiplex command on stick...)
+
+# Brakes
+# Allow, on flight to put in the same button, the brakes and airbrakes, using
+# defaults function, and put it on the joystick, and be able to accelerate and
+# decelerate without put hand of the stick and search the keyboard.
+
+# AirBrake handling.
+var fullAirBrakeTime = 0;
+var applyAirBrakes = func(v)
+{
+    interpolate("/controls/flight/speedbrake", v, fullAirBrakeTime);
+}
+
+# Brake handling.
+var fullBrakeTime = 0.5;
+var applyBrakes = func(v, which = 0)
+{
+    if(getprop("/controls/gear/gear-down") != 0)
+    {
+        if(which <= 0)
+        {
+            interpolate("/controls/gear/brake-left", v, fullBrakeTime);
+        }
+        if(which >= 0)
+        {
+            interpolate("/controls/gear/brake-right", v, fullBrakeTime);
+        }
+    }
+    else
+    {
+        controls.applyAirBrakes(v);
+    }
+}
+

--- a/f16-base.xml
+++ b/f16-base.xml
@@ -936,6 +936,9 @@
         <awg_9>
             <file>Aircraft/f16/Nasal/awg_9.nas</file>
         </awg_9>
+        <controls>
+            <file>Aircraft/f16/Nasal/f16_controls.nas</file>
+        </controls>
         <f16> 
             <file>Aircraft/f16/Nasal/f16.nas</file>
             <file>Aircraft/f16/Nasal/liveries.nas</file>


### PR DESCRIPTION
Pushing b when glanding gear retracted will deploy airbrake, when releasing b will make airbrakes retract them. When gear are deployed  "b" is just brakes. Ctrl-b is still working. This will allow "little airbrake deployement" in order to adjust the speed when refueling.