### PR TITLE
Control: Fix 'wobbly' heading control at low speed while keeping inte…

### DIFF
--- a/Systems/autoflight.xml
+++ b/Systems/autoflight.xml
@@ -172,12 +172,19 @@
 			</function>
 		</fcs_function>
 		
-		<switch name="autoflight/roll/heading/i-gain">
-			<default value="0"/>
-			<test value="1.2">
-				autoflight/roll/gain-switch eq 0
-			</test>
-		</switch>
+		<fcs_function name="autoflight/roll/heading/i-gain">
+			<function>
+				<table>
+					<independentVar lookup="row">velocities/mach</independentVar>
+					<independentVar lookup="column">autoflight/roll/gain-switch</independentVar>
+					<tableData>
+						     0      1  
+						0.4  0.005  0.000
+						1.0  1.100  0.000
+					</tableData>
+				</table>
+			</function>
+		</fcs_function>
 		
 		<switch name="autoflight/roll/heading/trigger">
 			<default value="0"/>


### PR DESCRIPTION
…grator control at high speed working

The fix for high speed heading control caused the low speed control to become 'wobbly' and not level out nicely, so that is fixed now while preserving the fix for the previous heading issue at high speed.