### PR TITLE
Control: Remove the roll rate double inverting

### DIFF
--- a/Systems/autoflight.xml
+++ b/Systems/autoflight.xml
@@ -387,12 +387,9 @@
 		
 		<fcs_function name="autoflight/roll/roll-rate-deg">
 			<function>
-				<product>
-					<todegrees>
-						<property>autoflight/roll/master-pid</property>
-					</todegrees>
-					<value>-1</value> <!-- Rate for some reason is inverted -->
-				</product>
+				<todegrees>
+					<property>autoflight/roll/master-pid</property>
+				</todegrees>
 			</function>
 		</fcs_function>
 		

--- a/Systems/jsb-controls.xml
+++ b/Systems/jsb-controls.xml
@@ -604,7 +604,7 @@
             <input>-fcs/fly-by-wire/roll/loop-lag</input>
             <input>-fcs/fly-by-wire/roll/trim-gain</input>
             <input>fcs/fly-by-wire/roll/roll-filter</input>
-            <input>autoflight/roll/roll-rate-demand</input><!-- should be negative input, fix later -->
+            <input>-autoflight/roll/roll-rate-demand</input>
         </summer>
 
         <pure_gain name="fcs/fly-by-wire/roll/trim-gain">


### PR DESCRIPTION
Didn't notice the negative signs when I first added the Roll Control -- now fixed, removing the double inverting.