### PR TITLE
Updated AP to V3.2 Spec: Bugfixes and Improvements

### DIFF
--- a/Systems/autoflight-rules.xml
+++ b/Systems/autoflight-rules.xml
@@ -79,31 +79,6 @@
 		</period>
 	</filter>
 	
-	<predict-simple>
-		<name>ALTITUDE 2 SECONDS AHEAD</name>
-		<debug>false</debug>
-		<input>/instrumentation/altimeter/indicated-altitude-ft</input>
-		<output>/fdm/jsbsim/autoflight/pitch/altitude-2-sec-ahead</output>
-		<seconds>5.0</seconds>
-		<filter-gain>0.0</filter-gain>
-	</predict-simple>
-	
-	<filter>
-		<name>IT-CONTROLLER: FPM KP (P Gain)</name>
-		<type>gain</type>
-		<gain>1.0</gain>
-		<input>
-			<expression>
-				<table>
-					<property>/velocities/mach</property>
-					<entry><ind>0.2</ind><dep>0.0021</dep></entry>
-					<entry><ind>1.4</ind><dep>0.0007</dep></entry>
-				</table>
-			</expression>
-		</input>
-		<output>/fdm/jsbsim/autoflight/pitch/vs/p-gain</output>
-	</filter>
-	
 	<filter>
 		<name>PITCH DEG SYNC</name>
 		<type>gain</type>
@@ -124,6 +99,8 @@
 		</enable>
 		<input>/orientation/pitch-deg</input>
 		<output>/fdm/jsbsim/autoflight/pitch/vs/pid</output>
+		<min>-15</min>
+		<max>30</max>
 	</filter>
  
 	<pid-controller>
@@ -154,7 +131,14 @@
 		</output>
 		<config>
 			<Kp>
-				<property>/fdm/jsbsim/autoflight/pitch/vs/p-gain</property>
+				<expression>
+					<table>
+						<property>/velocities/mach</property>
+						<entry><ind>0.2</ind><dep>0.0029</dep></entry>
+						<entry><ind>0.9</ind><dep>0.0010</dep></entry>
+						<entry><ind>2.1</ind><dep>0.0003</dep></entry>
+					</table>
+				</expression>
 			</Kp>
 			<Ti>2.0</Ti>
 			<Td>0.0001</Td>
@@ -171,7 +155,15 @@
 						</equals>
 					</and>
 				</condition>
-				<value>-15</value>
+				<expression>
+					<max>
+						<dif>
+							<property>/orientation/pitch-deg</property>
+							<value>5</value>
+						</dif>
+						<value>-15</value>
+					</max>
+				</expression>
 			</u_min>
 			<u_min>
 				<condition>
@@ -201,7 +193,15 @@
 						</equals>
 					</and>
 				</condition>
-				<value>30</value>
+				<expression>
+					<min>
+						<sum>
+							<property>/orientation/pitch-deg</property>
+							<value>5</value>
+						</sum>
+						<value>30</value>
+					</min>
+				</expression>
 			</u_max>
 			<u_max>
 				<condition>

--- a/Systems/autoflight.xml
+++ b/Systems/autoflight.xml
@@ -235,6 +235,33 @@
 		
 		<!-- ALT HOLD -->
 		
+		<fcs_function name="autoflight/pitch/alt/gain">
+			<function>
+				<table>
+					<independentVar lookup="row">velocities/mach</independentVar>
+					<tableData>
+						0.2 -7
+						2.1 -5
+					</tableData>
+				</table>
+			</function>
+		</fcs_function>
+		
+		<fcs_function name="autoflight/pitch/alt/predicted">
+			<function>
+				<sum>
+					<quotient>
+						<property>/instrumentation/gps/indicated-vertical-speed</property>
+						<product>
+							<property>autoflight/pitch/alt/gain</property>
+							<value>-1</value>
+						</product>
+					</quotient>
+					<property>/instrumentation/altimeter/indicated-altitude-ft</property>
+				</sum>
+			</function>
+		</fcs_function>
+		
 		<fcs_function name="autoflight/pitch/alt/target">
 			<function>
 				<product>
@@ -253,7 +280,7 @@
 										</eq>
 									</and>
 									<property>autoflight/pitch/alt/target</property>
-									<property>autoflight/pitch/altitude-2-sec-ahead</property>
+									<property>autoflight/pitch/alt/predicted</property>
 								</ifthen>
 								<value>50</value> <!-- Make the integer rounded correctly -->
 							</sum>
@@ -268,15 +295,16 @@
 		<fcs_function name="autoflight/pitch/alt/error">
 			<function>
 				<difference>
-					<property>autoflight/pitch/altitude-2-sec-ahead</property>
+					<property>/instrumentation/altimeter/indicated-altitude-ft</property>
 					<property>autoflight/pitch/alt/target</property>
+					<value>2</value>
 				</difference>
 			</function>
 		</fcs_function>
 		
 		<pure_gain name="autoflight/pitch/vs/target">
 			<input>autoflight/pitch/alt/error</input>
-			<gain>-4</gain>
+			<gain>autoflight/pitch/alt/gain</gain>
 		</pure_gain>
 	
 	</channel>
@@ -560,6 +588,19 @@
 			</function>
 		</fcs_function>
 		
+		<fcs_function name="autoflight/pitch/i-gain-att">
+			<function>
+				<table>
+					<independentVar lookup="row">velocities/mach</independentVar>
+					<tableData>
+						0.2 -2
+						1.0 -4
+						2.0 -5
+					</tableData>
+				</table>
+			</function>
+		</fcs_function>
+		
 		<switch name="autoflight/pitch/p-gain">
 			<default value="0"/>
 			<test logic="AND" value="autoflight/pitch/p-gain-att">
@@ -603,19 +644,33 @@
 			<output>autoflight/pitch/master-pid</output>
 		</pid>
 		
-		<pure_gain name="autoflight/pitch/g-demand-inverted"> <!-- Invert the G command -->
-			<input>autoflight/pitch/master-pid</input>
-			<gain>-1.0</gain>
-		</pure_gain>
+		<fcs_function name="autoflight/pitch/g-demand"> <!-- Offset the G demand for rolling, better then integrating -->
+			<function>
+				<sum>
+					<property>autoflight/pitch/master-pid</property>
+					<quotient>
+						<value>1</value>
+						<cos>
+							<property>attitude/roll-rad</property>
+						</cos>
+					</quotient>
+					<value>-1</value>
+				</sum>
+			</function>
+			<clipto>
+				<min>-0.5</min> <!-- 0.5 G -->
+				<max>1.0</max> <!-- 2.0 G -->
+			</clipto>
+		</fcs_function>
 		
 		<switch name="autoflight/pitch/g-demand-switched">
 			<default value="0"/>
-			<test logic="AND" value="autoflight/pitch/g-demand-inverted">
+			<test logic="AND" value="autoflight/pitch/g-demand">
 				autoflight/output/pitch-master eq 1
 			</test>
 			<clipto>
-				<min>-1.0</min>
-				<max>0.5</max>
+				<min>-0.5</min> <!-- 0.5 G -->
+				<max>1.0</max> <!-- 2.0 G -->
 			</clipto>
 		</switch>
 	

--- a/Systems/jsb-controls.xml
+++ b/Systems/jsb-controls.xml
@@ -1564,7 +1564,7 @@
         <summer name="fcs/fly-by-wire/pitch/command-sum-limit-alpha">
             <input> -fcs/fly-by-wire/pitch/command-sum-limit-lagged </input>
             <input> fcs/fly-by-wire/pitch/alpha-indicated-gain </input>
-            <input> autoflight/pitch/g-demand-switched </input>
+            <input> -autoflight/pitch/g-demand-switched </input>
         </summer>
 
         <summer name="fcs/fly-by-wire/pitch/command-sum-limit-alpha-pitch">

--- a/f16-base.xml
+++ b/f16-base.xml
@@ -995,7 +995,7 @@
                 <pitch>
                     <altitude-2-sec-ahead type="double">0</altitude-2-sec-ahead> <!-- autoflight-rules.xml -->
                     <d-gain-att type="double">-5</d-gain-att>
-                    <i-gain-att type="double">-1</i-gain-att>
+                    <i-gain-att type="double">0</i-gain-att> <!-- This gain is dynamic -->
                     <master-pid type="double">0</master-pid>
                     <p-gain-att type="double">0</p-gain-att> <!-- This gain is dynamic -->
                     <vs>


### PR DESCRIPTION
* Fixed: Pitch too slow to compensate during turns
* Fixed: V/S instability at high speed or altitude
* Fixed: V/S is not precise at low speed
* Fixed: ALT hold instability at high speed
* Fixed: ALT hold poor behavior in certain extreme conditions
* Improved: ALT hold behavior
* Improved: Dynamic gains for V/S
* Changed: Altitude Predictor

Kind Regards,
Josh