### PR TITLE
Add Aft and Fwd selection to engine feed knob.

### DIFF
--- a/Models/Cockpit/Main/panels_mlu_left-console.xml
+++ b/Models/Cockpit/Main/panels_mlu_left-console.xml
@@ -1032,8 +1032,8 @@
         <drag-scale-px>10</drag-scale-px><!-- 10 is default -->
         <repeatable>true</repeatable>
         <interval-sec>0.75</interval-sec>
-        <factor>-40</factor>
-        <offset-deg>40</offset-deg>
+        <factor>-47</factor>
+        <offset-deg>45</offset-deg>
         <center>
           <x-m>0.498453</x-m>
           <y-m>-0.511119</y-m>
@@ -1050,7 +1050,7 @@
                 <property>f16/engine/feed</property>
                 <step>1</step>
                 <min>0</min>
-                <max>1</max>
+                <max>3</max>
                 <wrap>false</wrap>
            </binding>
         </increase>
@@ -1060,7 +1060,7 @@
                 <property>f16/engine/feed</property>
                 <step>-1</step>
                 <min>0</min>
-                <max>1</max>
+                <max>3</max>
                 <wrap>false</wrap>
            </binding>
         </decrease>

--- a/Nasal/f16.nas
+++ b/Nasal/f16.nas
@@ -1897,6 +1897,25 @@ setlistener("f16/engine/cutoff-release-lever", func() {
 	}
 }, 0, 0);
 
+# Engine feed knob handler
+setlistener("f16/engine/feed", func(feedNode) {
+    var feed = feedNode.getValue();
+    if (feed == 1) # NORM
+    {
+        setprop("/fdm/jsbsim/propulsion/tank[0]/priority", 5);
+        setprop("/fdm/jsbsim/propulsion/tank[3]/priority", 5);
+    }
+    if (feed == 2) # AFT
+    {
+        setprop("/fdm/jsbsim/propulsion/tank[0]/priority", 5);
+        setprop("/fdm/jsbsim/propulsion/tank[3]/priority", 1);
+    }
+    if (feed == 3) # FWD
+    {
+        setprop("/fdm/jsbsim/propulsion/tank[0]/priority", 1);
+        setprop("/fdm/jsbsim/propulsion/tank[3]/priority", 5);
+    }
+}, 0, 0);
 
 var main_init_listener = setlistener("sim/signals/fdm-initialized", func {
   if (getprop("sim/signals/fdm-initialized") == 1) {

--- a/Systems/jsb-propulsion-block1.xml
+++ b/Systems/jsb-propulsion-block1.xml
@@ -54,7 +54,7 @@
    <capacity unit="LBS"> 2640.0 </capacity>
    <contents unit="LBS"> 2640.0 </contents>
    <type>JP-4</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left wing tank -->
    <location unit="IN">
@@ -65,7 +65,7 @@
    <capacity unit="LBS"> 525 </capacity>
    <contents unit="LBS"> 525 </contents>
    <type>JP-4</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right wing tank -->
    <location unit="IN">
@@ -76,7 +76,7 @@
    <capacity unit="LBS"> 525 </capacity>
    <contents unit="LBS"> 525 </contents>
    <type>JP-4</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Tank A-1 -->
    <location unit="IN">
@@ -87,7 +87,7 @@
    <capacity unit="LBS"> 2215.0 </capacity>
    <contents unit="LBS"> 2215.0 </contents>
    <type>JP-4</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- FWD Reservoir -->
     <location unit="IN">
@@ -98,7 +98,7 @@
    <capacity unit="LBS"> 460.0 </capacity>
    <contents unit="LBS"> 460.0 </contents>
    <type>JP-4</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Reservoir -->
     <location unit="IN">
@@ -109,7 +109,7 @@
    <capacity unit="LBS"> 460.0 </capacity>
    <contents unit="LBS"> 460.0 </contents>
    <type>JP-4</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left External Tank -->
    <location unit="IN">
@@ -120,7 +120,7 @@
    <capacity unit="LBS"> 3750 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-4</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right External Tank -->
    <location unit="IN">
@@ -131,7 +131,7 @@
    <capacity unit="LBS"> 3750 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-4</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Center External Tank -->
    <location unit="IN">
@@ -142,6 +142,6 @@
    <capacity unit="LBS"> 1800 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-4</type>
-   <priority> 1 </priority>
+   <priority> 2 </priority>
   </tank>
  </propulsion>

--- a/Systems/jsb-propulsion-block30.xml
+++ b/Systems/jsb-propulsion-block30.xml
@@ -54,7 +54,7 @@
    <capacity unit="LBS"> 2770.0 </capacity>
    <contents unit="LBS"> 2770.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left wing tank -->
    <location unit="IN">
@@ -65,7 +65,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right wing tank -->
    <location unit="IN">
@@ -76,7 +76,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Tank A-1 -->
    <location unit="IN">
@@ -87,7 +87,7 @@
    <capacity unit="LBS"> 2330.0 </capacity>
    <contents unit="LBS"> 2330.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- FWD Reservoir -->
     <location unit="IN">
@@ -98,7 +98,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Reservoir -->
     <location unit="IN">
@@ -109,7 +109,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left External Tank -->
    <location unit="IN">
@@ -120,7 +120,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right External Tank -->
    <location unit="IN">
@@ -131,7 +131,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Center External Tank -->
    <location unit="IN">
@@ -142,6 +142,6 @@
    <capacity unit="LBS"> 1890 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 1 </priority>
+   <priority> 2 </priority>
   </tank>
  </propulsion>

--- a/Systems/jsb-propulsion-block32.xml
+++ b/Systems/jsb-propulsion-block32.xml
@@ -54,7 +54,7 @@
    <capacity unit="LBS"> 2770.0 </capacity>
    <contents unit="LBS"> 2770.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left wing tank -->
    <location unit="IN">
@@ -65,7 +65,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right wing tank -->
    <location unit="IN">
@@ -76,7 +76,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Tank A-1 -->
    <location unit="IN">
@@ -87,7 +87,7 @@
    <capacity unit="LBS"> 2330.0 </capacity>
    <contents unit="LBS"> 2330.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- FWD Reservoir -->
     <location unit="IN">
@@ -98,7 +98,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Reservoir -->
     <location unit="IN">
@@ -109,7 +109,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left External Tank -->
    <location unit="IN">
@@ -120,7 +120,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right External Tank -->
    <location unit="IN">
@@ -131,7 +131,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Center External Tank -->
    <location unit="IN">
@@ -142,6 +142,6 @@
    <capacity unit="LBS"> 1890 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 1 </priority>
+   <priority> 2 </priority>
   </tank>
  </propulsion>

--- a/Systems/jsb-propulsion-block50.xml
+++ b/Systems/jsb-propulsion-block50.xml
@@ -54,7 +54,7 @@
    <capacity unit="LBS"> 2770.0 </capacity>
    <contents unit="LBS"> 2770.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left wing tank -->
    <location unit="IN">
@@ -65,7 +65,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right wing tank -->
    <location unit="IN">
@@ -76,7 +76,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Tank A-1 -->
    <location unit="IN">
@@ -87,7 +87,7 @@
    <capacity unit="LBS"> 2330.0 </capacity>
    <contents unit="LBS"> 2330.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- FWD Reservoir -->
     <location unit="IN">
@@ -98,7 +98,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Reservoir -->
     <location unit="IN">
@@ -109,7 +109,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left External Tank -->
    <location unit="IN">
@@ -120,7 +120,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right External Tank -->
    <location unit="IN">
@@ -131,7 +131,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Center External Tank -->
    <location unit="IN">
@@ -142,6 +142,6 @@
    <capacity unit="LBS"> 1890 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 1 </priority>
+   <priority> 2 </priority>
   </tank>
  </propulsion>

--- a/Systems/jsb-propulsion-block52.xml
+++ b/Systems/jsb-propulsion-block52.xml
@@ -54,7 +54,7 @@
    <capacity unit="LBS"> 2770.0 </capacity>
    <contents unit="LBS"> 2770.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left wing tank -->
    <location unit="IN">
@@ -65,7 +65,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right wing tank -->
    <location unit="IN">
@@ -76,7 +76,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Tank A-1 -->
    <location unit="IN">
@@ -87,7 +87,7 @@
    <capacity unit="LBS"> 2330.0 </capacity>
    <contents unit="LBS"> 2330.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- FWD Reservoir -->
     <location unit="IN">
@@ -98,7 +98,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Reservoir -->
     <location unit="IN">
@@ -109,7 +109,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left External Tank -->
    <location unit="IN">
@@ -120,7 +120,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right External Tank -->
    <location unit="IN">
@@ -131,7 +131,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Center External Tank -->
    <location unit="IN">
@@ -142,6 +142,6 @@
    <capacity unit="LBS"> 1890 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 1 </priority>
+   <priority> 2 </priority>
   </tank>
  </propulsion>

--- a/Systems/jsb-propulsion-block60.xml
+++ b/Systems/jsb-propulsion-block60.xml
@@ -54,7 +54,7 @@
    <capacity unit="LBS"> 2770.0 </capacity>
    <contents unit="LBS"> 2770.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left wing tank -->
    <location unit="IN">
@@ -65,7 +65,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right wing tank -->
    <location unit="IN">
@@ -76,7 +76,7 @@
    <capacity unit="LBS"> 550 </capacity>
    <contents unit="LBS"> 550 </contents>
    <type>JP-8</type>
-   <priority> 3 </priority>
+   <priority> 4 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Tank A-1 -->
    <location unit="IN">
@@ -87,7 +87,7 @@
    <capacity unit="LBS"> 2330.0 </capacity>
    <contents unit="LBS"> 2330.0 </contents>
    <type>JP-8</type>
-   <priority> 4 </priority>
+   <priority> 5 </priority>
   </tank>
   <tank type="FUEL"> <!-- FWD Reservoir -->
     <location unit="IN">
@@ -98,7 +98,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- AFT Reservoir -->
     <location unit="IN">
@@ -109,7 +109,7 @@
    <capacity unit="LBS"> 480.0 </capacity>
    <contents unit="LBS"> 480.0 </contents>
    <type>JP-8</type>
-   <priority> 5 </priority>
+   <priority> 6 </priority>
   </tank>
   <tank type="FUEL"> <!-- Left External Tank -->
    <location unit="IN">
@@ -120,7 +120,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Right External Tank -->
    <location unit="IN">
@@ -131,7 +131,7 @@
    <capacity unit="LBS"> 3925 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 2 </priority>
+   <priority> 3 </priority>
   </tank>
   <tank type="FUEL"> <!-- Center External Tank -->
    <location unit="IN">
@@ -142,6 +142,6 @@
    <capacity unit="LBS"> 1890 </capacity>
    <contents unit="LBS"> 0 </contents>
    <type>JP-8</type>
-   <priority> 1 </priority>
+   <priority> 2 </priority>
   </tank>
  </propulsion>

--- a/f16-base.xml
+++ b/f16-base.xml
@@ -3586,7 +3586,7 @@ value. 18000=standard US transition altitude -->
         </fcs>
         <engine>
 			<ctl-sec type="bool">false</ctl-sec>
-            <feed type="bool">false</feed><!-- OFF/NORM prevents starter, cutoff -->
+            <feed type="int">0</feed><!-- OFF/NORM prevents starter, cutoff -->
             <jet-fuel type="int">0</jet-fuel><!-- starter -1=1 1=2 0=off  goes to off at 55% rpm -->
             <jfs-start type="bool">false</jfs-start><!-- inverse cutoff -->
             <running-state type="bool">false</running-state>

--- a/states/approach.xml
+++ b/states/approach.xml
@@ -56,7 +56,7 @@
         
         <f16>
             <engine>
-                <feed type="bool">true</feed><!-- OFF/NORM prevents starter, cutoff -->
+                <feed type="int">1</feed><!-- OFF/NORM prevents starter, cutoff -->
                 <jfs-start-switch type="int">0</jfs-start-switch><!-- starter -1=1 1=2 0=off  goes to off at 55% rpm -->
                 <cutoff-release-lever type="bool">false</cutoff-release-lever><!-- cutoff -->
                 <running-state type="bool">true</running-state>

--- a/states/cruise.xml
+++ b/states/cruise.xml
@@ -54,7 +54,7 @@
         </engines>
         <f16>
             <engine>
-                <feed type="bool">true</feed><!-- OFF/NORM prevents starter, cutoff -->
+                <feed type="int">1</feed><!-- OFF/NORM prevents starter, cutoff -->
                 <jfs-start-switch type="int">0</jfs-start-switch><!-- starter -1=1 1=2 0=off  goes to off at 55% rpm -->
                 <cutoff-release-lever type="bool">false</cutoff-release-lever><!-- cutoff -->
                 <running-state type="bool">true</running-state>

--- a/states/ramp.xml
+++ b/states/ramp.xml
@@ -37,7 +37,7 @@
         </engines>
         <f16>
             <engine>
-                <feed type="bool">false</feed><!-- OFF/NORM prevents starter, cutoff -->
+                <feed type="int">0</feed><!-- OFF/NORM prevents starter, cutoff -->
                 <jfs-start-switch type="int">0</jfs-start-switch><!-- starter -1=1 1=2 0=off  goes to off at 55% rpm -->
                 <cutoff-release-lever type="bool">true</cutoff-release-lever><!-- cutoff -->
                 <running-state type="bool">false</running-state>

--- a/states/running.xml
+++ b/states/running.xml
@@ -50,7 +50,7 @@
         </engines>
         <f16>
             <engine>
-                <feed type="bool">true</feed><!-- OFF/NORM prevents starter, cutoff -->
+                <feed type="int">1</feed><!-- OFF/NORM prevents starter, cutoff -->
                 <jfs-start-switch type="int">0</jfs-start-switch><!-- starter -1=1 1=2 0=off  goes to off at 55% rpm -->
                 <cutoff-release-lever type="bool">false</cutoff-release-lever><!-- cutoff -->
                 <running-state type="bool">true</running-state>


### PR DESCRIPTION
Allow the Engine Feed knob to turn to the Aft and Fwd position.
When doing so change the priority of the relevant tanks so the
engine is fed from that tank first.