### PR TITLE
FLCS fixes and improvements based on 1987 diagram

### DIFF
--- a/Systems/jsb-controls.xml
+++ b/Systems/jsb-controls.xml
@@ -774,16 +774,16 @@
                 7 in flight CAT III at 100 KCAS.
                 DNU
 				
-				LJQC: Fixed 15.0 in 189675, unrelated to CAT I/III or landing gains.
+				LJQC: Fixed 15.8 in 189675, unrelated to CAT I/III or landing gains. Cross checked the value with BMS developer mav-jp.
             </description>
             <function>
                 <table>
                     <independentVar lookup="row">fcs/fly-by-wire/pitch/enable-cat-III</independentVar>
                     <independentVar lookup="column">velocities/vc-kts</independentVar>
                     <tableData>
-                           100 420
-                        0    15   15
-                        1    15   15
+                             100    420
+                        0    15.8   15.8
+                        1    15.8   15.8
                     </tableData>
                 </table>
             </function>
@@ -794,7 +794,7 @@
                 Diagram say condition A, changed so this don't kick in
                 when doing AAR.
 				
-				LJQC: 15 bias no change in AAR.
+				LJQC: 15.8 bias no change in AAR.
             </description>
             <default value="0"/>
             <test logic="OR" value="0">
@@ -992,8 +992,8 @@
 		
 		<pure_gain name="fcs/fly-by-wire/pitch/pitch-rate-cmd-gained">
 			<description>
-				LJQC: (AOA - 10)*0.X05, take pos val, and adds to the pitch rate feedback path.
-				Check: 0.X05 too blurry to read. Reference: 1G stall at 21 deg AOA according to 1F-16CJ-1.
+				LJQC: (AOA - 10)*0.105, take pos val, and adds to the pitch rate feedback path.
+				The gain is 0.105, cross checked with BMS developer mav-jp.
             </description>
             <input>fcs/fly-by-wire/pitch/pitch-rate-cmd-sum</input>
             <gain> 0.105 </gain>

--- a/Systems/jsb-controls.xml
+++ b/Systems/jsb-controls.xml
@@ -437,9 +437,9 @@
                 <table>
                     <independentVar lookup="row">fcs/elevator-cmd-norm</independentVar>
                     <tableData>
-                       -1   31.25
+                       -1   32
                         0    0
-                        1  -31.25
+                        1  -32
                     </tableData>
                 </table>
             </function>
@@ -453,12 +453,12 @@
                 <table>
                     <independentVar lookup="row">fcs/fly-by-wire/pitch/stick-force-lbf</independentVar>
                     <tableData>
-                       -31.25  -10.86
-                        -5.25  -0.44
+                        -32.0   -10.86
+                        -6.0    -0.44
                         -1.75   0.0
-                         1.75   0.0
-                         5.25   0.44 
-                        31.25  10.86
+                        1.75    0.0
+                        6.0     0.44 
+                        32.0    10.86
                     </tableData>
                 </table>
             </function>

--- a/Systems/jsb-controls.xml
+++ b/Systems/jsb-controls.xml
@@ -862,7 +862,7 @@
         <pure_gain name="fcs/fly-by-wire/pitch/pitch-rate-lower">
 			<description>
                     LJQC: This part not exist in Analog or Digital FLCS.
-					GR1F-16CJ-1: Pitch rate command until 10 deg AOA.
+					1F-16CJ-1: Pitch rate command until 10 deg AOA.
             </description>
             <input>fcs/fly-by-wire/pitch/pitch-rate-gain-sum-gain</input>
             <gain> 0 </gain>
@@ -1504,8 +1504,6 @@
             <description>
                 The -1 factor was removed since it was wrong. When more than
                 5 deg nosedown elev is commanded this comes into effect.
-				
-				LJQC: Should be more than 4.2 deg elev leading edge down. Todo: check.
             </description>
             <function>
                 <product>
@@ -1526,7 +1524,7 @@
 		
 		<switch name="fcs/fly-by-wire/roll/bias-catiii">
             <description>
-                LJQC: 136 deg/s cat-III bias added to roll rate limiter.
+                LJQC: 136 deg/s cat-III bias is actually added to the roll rate limiter, max limited by 244.
             </description>
             <default value="0"/>
             <test logic="OR" value="136">
@@ -1578,17 +1576,31 @@
                 fcs/fly-by-wire/control-c-actual == 1
             </test>
         </switch>
+		
+		<switch name="fcs/fly-by-wire/roll/max-cmd-roll-rate-gain-switch">
+            <description>
+                LJQC: According to 189675, 167deg/s is a direct overriding limit by roll rate command limiter, instead of applying a 0.542208 gain.
+            </description>
+            <default value="fcs/fly-by-wire/roll/max-cmd-roll-rate"/>
+            <test logic="OR" value="167">
+                fcs/fly-by-wire/condition-a == 1
+                fcs/fly-by-wire/digital-backup == 1
+            </test>
+        </switch>
 
         <fcs_function name="fcs/fly-by-wire/roll/min-cmd-roll-rate">
             <function>
                 <quotient>
-                    <p>fcs/fly-by-wire/roll/max-cmd-roll-rate</p>
+                    <p>fcs/fly-by-wire/roll/max-cmd-roll-rate-gain-switch</p>
                     <v>324</v>
                 </quotient>
             </function>
         </fcs_function>
 
         <fcs_function name="fcs/fly-by-wire/roll/command-deg_s">
+			<description>
+                LJQC: command gradient according to 189675.
+            </description>
             <function>
                 <product>
                 <table>
@@ -1622,6 +1634,9 @@
         </switch>
 
         <fcs_function name="fcs/fly-by-wire/roll/command-limited-deg_s">
+			<description>
+                LJQC: Already accounted for at above. No usage here.
+            </description>
             <function>
                 <product>
                     <table>
@@ -1655,22 +1670,14 @@
                 <max>  40 </max>
             </range>
         </aerosurface_scale>
-
-        <switch name="fcs/fly-by-wire/roll/gain-switch">
-            <description>
-                GR1F-16CJ-1 page 120
-                DBU - Maximum roll rate command is a constant 167 degrees per second.
-            </description>
-            <default value="1.0"/>
-            <test logic="OR" value="0.542">
-                fcs/fly-by-wire/condition-a == 1
-                fcs/fly-by-wire/digital-backup == 1
-            </test>
-        </switch>
+		
 
         <pure_gain name="fcs/fly-by-wire/roll/ground-gain">
+			<description>
+                LJQC: Already accounted for at above. No usage here.
+            </description>
             <input>fcs/fly-by-wire/roll/command-limited-deg_s</input>
-            <gain> fcs/fly-by-wire/roll/gain-switch </gain>
+            <gain> 1.0 </gain>
         </pure_gain>
 
         <summer name="fcs/fly-by-wire/roll/loop-sum">

--- a/Systems/jsb-controls.xml
+++ b/Systems/jsb-controls.xml
@@ -992,11 +992,11 @@
 		
 		<pure_gain name="fcs/fly-by-wire/pitch/pitch-rate-cmd-gained">
 			<description>
-				LJQC: (AOA - 10)*0.305, take pos val, and adds to the pitch rate feedback path.
-				Check: 1G stall at 21 deg AOA according to 1F-16CJ-1.
+				LJQC: (AOA - 10)*0.X05, take pos val, and adds to the pitch rate feedback path.
+				Check: 0.X05 too blurry to read. Reference: 1G stall at 21 deg AOA according to 1F-16CJ-1.
             </description>
             <input>fcs/fly-by-wire/pitch/pitch-rate-cmd-sum</input>
-            <gain> 0.305 </gain>
+            <gain> 0.105 </gain>
 			<clipto>
                 <min> 0 </min>
                 <max>10000</max>
@@ -1005,6 +1005,9 @@
         
 
         <summer name="fcs/fly-by-wire/pitch/pitch-rate-gain-path">
+			<description>
+				LJQC: the washed-out pitch rate is not added to this path.
+            </description>
             <input>fcs/fly-by-wire/pitch/q-lagged-gained </input>
 			<input> fcs/fly-by-wire/pitch/pitch-rate-cmd-gained </input>
         </summer>

--- a/Systems/jsb-controls.xml
+++ b/Systems/jsb-controls.xml
@@ -585,8 +585,18 @@
             <input> fcs/fly-by-wire/pitch/control-c/roll-rate-gain </input>
             <c1> 0.67 </c1>
         </lag_filter>
+		
+		<switch name="fcs/fly-by-wire/pitch/catiii-roll-rate-af-limit">
+            <default value="5.4"/>
+            <test logic="OR" value="2.7">
+                fcs/fly-by-wire/pitch/enable-cat-III == 1
+            </test>
+        </switch>
 
         <fcs_function name="fcs/fly-by-wire/pitch/control-c/roll-rate-schedule">
+			<description>
+				LJQC: Under CAT III it is limited to an output of 2.7, ref 189675.
+			</description>
             <function>
                 <table>
                     <independentVar lookup="row">fcs/fly-by-wire/pitch/control-c/roll-rate-lagged</independentVar>
@@ -597,6 +607,17 @@
                 </table>
             </function>
         </fcs_function>
+		
+		<summer name="fcs/fly-by-wire/pitch/roll-rate-schedule-limited">
+			<description>
+                LJQC: 189675 variable F. This is later used in yaw axis at rudder authority limiter.
+            </description>
+            <input>fcs/fly-by-wire/pitch/control-c/roll-rate-schedule</input>
+            <clipto>
+                <min>0</min>
+                <max>fcs/fly-by-wire/pitch/catiii-roll-rate-af-limit</max>
+            </clipto>
+        </summer>
 
         <switch name="fcs/fly-by-wire/control-c-actual">
             <description>
@@ -619,7 +640,7 @@
                       when rolling at high angle of attack.
                       its not used in yaw, ari or roll.
             </description>
-            <input> fcs/fly-by-wire/pitch/control-c/roll-rate-schedule </input>
+            <input> fcs/fly-by-wire/pitch/roll-rate-schedule-limited </input>
             <gain> fcs/fly-by-wire/control-c-actual </gain>
         </pure_gain>
 
@@ -632,7 +653,9 @@
         </lag_filter>
 
         <summer name="fcs/fly-by-wire/pitch/alpha-sum">
-            <description></description>
+            <description>
+				LJQC: According to 189675, alpha-sum only goes into the 20.4 limiter path. It doesn't goes into the 15.0/0.322 path.
+			</description>
             <input> fcs/fly-by-wire/pitch/a_f </input>
             <input> fcs/fly-by-wire/pitch/control-c/da_p </input>
         </summer>
@@ -688,7 +711,6 @@
         </fcs_function>
 
         <pure_gain name="fcs/fly-by-wire/pitch/high-alpha-cmd-neutralizer">
-            <description></description>
             <input>fcs/fly-by-wire/pitch/alpha-indicated-sum</input>
             <gain> 0.5 </gain>
             <clipto>
@@ -839,8 +861,10 @@
             <description>
                          Since this is part of pitch limiter scheme it
                          uses alpha-sum instead of a_f.
+						 
+						 LJQC: 189675 uses a_f instead of alpha-sum in this path. alpha-sum only used in the 20.4 path.
             </description>
-            <input>fcs/fly-by-wire/pitch/alpha-sum</input>
+            <input>fcs/fly-by-wire/pitch/a_f</input>
             <input> fcs/fly-by-wire/pitch/pitch-rate-gain </input>
             <input> -fcs/fly-by-wire/pitch/bias-final </input>
         </summer>
@@ -1504,6 +1528,8 @@
             <description>
                 The -1 factor was removed since it was wrong. When more than
                 5 deg nosedown elev is commanded this comes into effect.
+				
+				LJQC: 4.2 deg in 189675.
             </description>
             <function>
                 <product>
@@ -1775,6 +1801,8 @@
             <description>
                 Is +8.34 in diagram, but must be negative to really work as flat spin protection.
                 And for slow flat spins it was way too small.
+				
+				LJQC: 1.0 in 189675 (=8.34*0.12). So seems correct.
             </description>
             <input> velocities/r-deg_sec </input>
             <gain> -8.34 </gain>
@@ -2228,6 +2256,16 @@
                 fcs/fly-by-wire/digital-backup == 1
             </test>
         </switch>
+		
+		<pure_gain name="fcs/fly-by-wire/yaw/variable-F-gained">
+            <input>fcs/fly-by-wire/pitch/roll-rate-schedule-limited</input>
+            <gain> 4.0 </gain>
+        </pure_gain>
+		
+		<summer name="fcs/fly-by-wire/yaw/authority-limiter-input">
+            <input>fcs/fly-by-wire/pitch/a_f</input>
+            <input>fcs/fly-by-wire/yaw/variable-F-gained</input>
+        </summer>
 
         <fcs_function name="fcs/fly-by-wire/yaw/command-schedule">
             <description>
@@ -2236,11 +2274,13 @@
 
                 TODO: Consider using aero/alpha-deg here instead of a_f.
                       TP-1538 does say it uses alpha indicated directly.
+					  
+				LJQC: 189675 uses a_f + variable-F * 4.0.
             </description>
             <function>
                 <product>
                     <table>
-                        <independentVar lookup="row">fcs/fly-by-wire/pitch/a_f</independentVar>
+                        <independentVar lookup="row">fcs/fly-by-wire/yaw/authority-limiter-input</independentVar>
                         <independentVar lookup="column">fcs/fly-by-wire/yaw/enable-cat-III</independentVar>
                         <tableData>
                                    0           1
@@ -2256,6 +2296,12 @@
         </fcs_function>
 
         <fcs_function name="fcs/fly-by-wire/yaw/control-c/command-schedule">
+			<description>
+				LJQC: In 189675, it is the variable F (fcs/fly-by-wire/pitch/roll-rate-schedule-limited)
+				multiplied by 4.0 that is added to the rudder authority limiter.
+				
+				This schedule not used in 189675.
+			</description>
             <function>
                 <product>
                     <table>
@@ -2264,7 +2310,7 @@
                         <tableData>
                                    0  1
                             20   1.0 1.0
-                            40   1.0 0.0
+                            40   1.0 1.0
                         </tableData>
                     </table>
                     <p>fcs/fly-by-wire/yaw/command-schedule</p>
@@ -2348,9 +2394,11 @@
             <description>
                 Is +0.75 in diagram.
                 TODO: check the validity
+				
+				LJQC: +0.75 valid in 189675. Rudder against the yaw.
             </description>
             <input> velocities/r-deg_sec </input>
-            <gain> -0.75 </gain>
+            <gain> 0.75 </gain>
         </pure_gain>
 
         <switch name="fcs/fly-by-wire/yaw/schedule-final">

--- a/Systems/jsb-controls.xml
+++ b/Systems/jsb-controls.xml
@@ -12,8 +12,6 @@
     ICAS-90-5.10.2 - used for MPO switch
     AFSC 32657C - has more clean view of Integrator pitch loop.
  -->
-    
-    <property value="0">fcs/fly-by-wire/diagram1987</property>
 
     <channel execrate="1" name="FCS Lookup">
 
@@ -27,16 +25,30 @@
                 gear/unit[2]/WOW eq 1
             </test>
         </switch>
-
-        <switch name="fcs/fly-by-wire/condition-a">
+		
+		<switch name="fcs/fly-by-wire/Note-5">
+			<description>
+                LJQC: Note 5 in 189675
+            </description>
             <default value="0"/>
             <test logic="OR" value="1">
                 gear/gear-cmd-norm == 1
                 /controls/flight/flaps gt 0
             </test>
+        </switch>
+
+        <switch name="fcs/fly-by-wire/condition-a">
+			<description>
+                LJQC: According to Note 1 in 189675, condition on q_c is 600.
+            </description>
+            <default value="0"/>
+            <test logic="AND" value="1">
+                fcs/fly-by-wire/Note-5 == 1
+                fcs/fly-by-wire/q_c lt 600
+            </test>
             <test logic="AND" value="1">
                 /systems/refuel/serviceable == 1
-                fcs/fly-by-wire/q_c lt 646
+                fcs/fly-by-wire/q_c lt 600
             </test>
         </switch>
         
@@ -58,10 +70,13 @@
         </switch>
         
         <switch name="fcs/fly-by-wire/condition-aar">
+			<description>
+                LJQC: According to 189675, condition on q_c is 600.
+            </description>
             <default value="0"/>
             <test logic="AND" value="1">
                 /systems/refuel/serviceable == 1
-                fcs/fly-by-wire/q_c lt 646
+                fcs/fly-by-wire/q_c lt 600
             </test>
         </switch>
         
@@ -247,6 +262,7 @@
         <fcs_function name="fcs/fly-by-wire/yaw/F8">
             <description>Yaw axis
                          TP-1538 is simplified to 0.5
+						 LJQC: Compensate for decrease in directional stability at higher mach. Since aero coeff is only for 0.6 mach, so we only need 0.5.
             </description>
             <function>
                 <table>
@@ -254,7 +270,7 @@
                     <tableData>
                         0.0  0.5
                         2.04 0.5
-                        3.23 1.0
+                        3.23 0.5
                     </tableData>
                 </table>
             </function>
@@ -414,29 +430,35 @@
         </switch>
 
         <fcs_function name="fcs/fly-by-wire/pitch/stick-force-lbf">
+			<description>
+                LJQC: Stick cmd gradient according to 189675. Stand true for both Analog and Digital FLCS.
+            </description>
             <function>
                 <table>
                     <independentVar lookup="row">fcs/elevator-cmd-norm</independentVar>
                     <tableData>
-                       -1   40
+                       -1   31.25
                         0    0
-                        1  -17.65
+                        1  -31.25
                     </tableData>
                 </table>
             </function>
         </fcs_function>
 
         <fcs_function name="fcs/fly-by-wire/pitch/command-g">
+			<description>
+                LJQC: Stick cmd gradient according to 189675. Stand true for both Analog and Digital FLCS.
+            </description>
             <function>
                 <table>
                     <independentVar lookup="row">fcs/fly-by-wire/pitch/stick-force-lbf</independentVar>
                     <tableData>
-                       -17.65  -4.0
-                        -7.25  -0.44
+                       -31.25  -10.86
+                        -5.25  -0.44
                         -1.75   0.0
                          1.75   0.0
-                         7.25   0.44 
-                        40.00  10.86
+                         5.25   0.44 
+                        31.25  10.86
                     </tableData>
                 </table>
             </function>
@@ -473,10 +495,13 @@
         </switch>
 
         <summer name="fcs/fly-by-wire/pitch/g-limit">
+			<description>
+                LJQC: Max g according to 189675.
+            </description>
             <input>fcs/fly-by-wire/pitch/command-sum</input>
             <clipto>
                 <min>fcs/fly-by-wire/pitch/negative-g-limit-final</min>
-                <max>8.0</max>
+                <max>8.3</max>
             </clipto>
         </summer>
 
@@ -523,10 +548,13 @@
         </switch>
 
         <summer name="fcs/fly-by-wire/pitch/alpha-indicated-clamp">
+			<description>
+                LJQC: 189675 value.
+            </description>
             <input>aero/alpha-deg</input><!-- should really be indicated -->
             <clipto>
-                <min>-5</min>
-                <max>30</max>
+                <min>-5.5</min>
+                <max>32.5</max>
             </clipto>
         </summer>
 
@@ -679,6 +707,11 @@
             <input>velocities/q-rad_sec</input>
             <gain> 57.2957795 </gain>
         </pure_gain>
+		
+		<lag_filter name="fcs/fly-by-wire/pitch/q-lagged">
+          <input> velocities/q-deg_sec </input>
+          <c1> 50 </c1>
+        </lag_filter>
 
         <washout_filter name="fcs/fly-by-wire/pitch/q-washout">
           <input> velocities/q-deg_sec </input>
@@ -701,8 +734,10 @@
                 However due to landing AoA should be 11 to 15,
                 The 6 bias is changed to 11.
                 DNU
+				
+				LJQC: Since AOA is nulled upon MLG WOW, so no such switch in 189675.
             </description>
-            <default value="6"/>
+            <default value="0"/>
             <test logic="AND" value="0">
                 fcs/fly-by-wire/MLG-GND == 1                
             </test>
@@ -716,6 +751,8 @@
                 changed so its still 15 in flight CAT I and
                 7 in flight CAT III at 100 KCAS.
                 DNU
+				
+				LJQC: Fixed 15.0 in 189675, unrelated to CAT I/III or landing gains.
             </description>
             <function>
                 <table>
@@ -723,8 +760,8 @@
                     <independentVar lookup="column">velocities/vc-kts</independentVar>
                     <tableData>
                            100 420
-                        0    9   9
-                        1    1   9
+                        0    15   15
+                        1    15   15
                     </tableData>
                 </table>
             </function>
@@ -734,9 +771,11 @@
             <description>
                 Diagram say condition A, changed so this don't kick in
                 when doing AAR.
+				
+				LJQC: 15 bias no change in AAR.
             </description>
             <default value="0"/>
-            <test logic="OR" value="fcs/fly-by-wire/pitch/bias-number">
+            <test logic="OR" value="0">
                 gear/gear-cmd-norm == 1
             </test>
         </switch>
@@ -821,12 +860,12 @@
         </pure_gain>
 
         <pure_gain name="fcs/fly-by-wire/pitch/pitch-rate-lower">
+			<description>
+                    LJQC: This part not exist in Analog or Digital FLCS.
+					GR1F-16CJ-1: Pitch rate command until 10 deg AOA.
+            </description>
             <input>fcs/fly-by-wire/pitch/pitch-rate-gain-sum-gain</input>
-            <gain> 1 </gain>
-            <clipto>
-                <min> -10000 </min>
-                <max> 0 </max>
-            </clipto>
+            <gain> 0 </gain>
         </pure_gain>
 
         <switch name="fcs/fly-by-wire/pitch/pitch-rate-lower-switch">
@@ -840,12 +879,12 @@
                 In diagram relies only on Condition A, but its not helpful during AAR,
                 nor right after take-off, it should really only get into effect when on
                 approach, hence that test.
+				
+				LJQC: Switch for cruise gains and landing gains.
             </description>
             <default value="0"/>
-            <test logic="AND" value="1.0">
-                <!-- fcs/fly-by-wire/condition-a == 1 -->
-                gear/gear-cmd-norm == 1
-                fcs/fly-by-wire/MLG-GND != 1
+            <test logic="AND" value="1">
+                fcs/fly-by-wire/condition-a == 1
             </test>
         </switch>
 
@@ -905,82 +944,64 @@
             <gain> 0.5 </gain>
         </pure_gain>
 
-        <switch name="fcs/fly-by-wire/pitch/q-product-1975">
-            <description></description>
-            <default value="0.167"/>
-            <test logic="AND" value="0.231">
-                fcs/fly-by-wire/MLG-GND == 1
-            </test>
-        </switch>
-        
-        <fcs_function name="fcs/fly-by-wire/pitch/q-product-1987">
-            <description>The 1987 diagram has 0.5 gain on condition-z, but its feedback gains is double of the 1975 diagram. So it is halved to 0.25</description>
-            <function>
-                <sum>
-                    <product>
-                        <property> fcs/fly-by-wire/condition-z </property>
-                        <value> 0.25 </value>
-                    </product>
-                    <product>
-                        <property> fcs/fly-by-wire/condition-y </property>
-                        <value> 0.167 </value>
-                    </product>
-                </sum>
-            </function>
-        </fcs_function>
-        
-        <switch name="fcs/fly-by-wire/pitch/q-product">
-            <description></description>
-            <default value="fcs/fly-by-wire/pitch/q-product-1975"/>
-            <test logic="AND" value="fcs/fly-by-wire/pitch/q-product-1987">
-                fcs/fly-by-wire/diagram1987 == 1
-            </test>
-        </switch>
-                
-        <fcs_function name="fcs/fly-by-wire/pitch/q-1987">
-            <function>
-                <sum>
-                    <product>
-                        <property> fcs/fly-by-wire/condition-z </property>
-                        <property> velocities/q-deg_sec </property>
-                    </product>
-                    <product>
-                        <property> fcs/fly-by-wire/condition-y </property>
-                        <property> fcs/fly-by-wire/pitch/q-washout </property>
-                    </product>
-                </sum>
-            </function>
-        </fcs_function>
-        
-        <switch name="fcs/fly-by-wire/pitch/q-washout-final">
-            <description></description>
-            <default value="fcs/fly-by-wire/pitch/q-washout"/>
-            <test logic="AND" value="fcs/fly-by-wire/pitch/q-1987">
-                fcs/fly-by-wire/diagram1987 == 1
-            </test>
-        </switch>
-
-        <pure_gain name="fcs/fly-by-wire/pitch/pitch-rate-second-path">
-            <input>fcs/fly-by-wire/pitch/q-washout-final </input>
-            <gain> fcs/fly-by-wire/pitch/q-product </gain>
+        <pure_gain name="fcs/fly-by-wire/pitch/q-washout-gained">
+            <input>fcs/fly-by-wire/pitch/q-washout</input>
+            <gain> 0.167 </gain>
         </pure_gain>
         
-        <pure_gain name="fcs/fly-by-wire/pitch/normal-gain-path-1987">
-            <input>fcs/fly-by-wire/pitch/normal-gain </input>
+        <pure_gain name="fcs/fly-by-wire/pitch/q-lagged-gained">
+            <input>fcs/fly-by-wire/pitch/q-lagged</input>
+            <gain> 0.25 </gain>
+        </pure_gain>
+		
+		<fcs_function name="fcs/fly-by-wire/pitch/pitch-rate-cmd-sum">
+			<description>
+				LJQC: (AOA - 10)
+            </description>
+            <function>
+                    <difference>
+                        <property> fcs/fly-by-wire/pitch/a_f </property>
+                        <value> 10 </value>
+                    </difference>
+            </function>
+        </fcs_function>
+		
+		<pure_gain name="fcs/fly-by-wire/pitch/pitch-rate-cmd-gained">
+			<description>
+				LJQC: (AOA - 10)*0.305, take pos val, and adds to the pitch rate feedback path.
+            </description>
+            <input>fcs/fly-by-wire/pitch/pitch-rate-cmd-sum</input>
+            <gain> 0.305 </gain>
+			<clipto>
+                <min> 0 </min>
+                <max>10000</max>
+            </clipto>
+        </pure_gain>
+        
+
+        <summer name="fcs/fly-by-wire/pitch/pitch-rate-gain-path">
+            <input>fcs/fly-by-wire/pitch/q-lagged-gained </input>
+			<input> fcs/fly-by-wire/pitch/pitch-rate-cmd-gained </input>
+        </summer>
+		
+		<pure_gain name="fcs/fly-by-wire/pitch/pitch-rate-gain-path-final">
+            <input>fcs/fly-by-wire/pitch/pitch-rate-gain-path </input>
+            <gain> fcs/fly-by-wire/condition-z </gain>
+        </pure_gain>
+		
+		<summer name="fcs/fly-by-wire/pitch/normal-gain-path">
+            <input>fcs/fly-by-wire/pitch/q-washout-gained </input>
+			<input> fcs/fly-by-wire/pitch/normal-gain </input>
+        </summer>
+        
+        <pure_gain name="fcs/fly-by-wire/pitch/normal-gain-path-final">
+            <input>fcs/fly-by-wire/pitch/normal-gain-path </input>
             <gain> fcs/fly-by-wire/condition-y </gain>
         </pure_gain>
         
-        <switch name="fcs/fly-by-wire/pitch/normal-gain-path">
-            <description></description>
-            <default value="fcs/fly-by-wire/pitch/normal-gain"/>
-            <test logic="AND" value="fcs/fly-by-wire/pitch/normal-gain-path-1987">
-                fcs/fly-by-wire/diagram1987 == 1
-            </test>
-        </switch>
-        
         <summer name="fcs/fly-by-wire/pitch/n-and-pitch-rate-combined">
-            <input> fcs/fly-by-wire/pitch/normal-gain-path </input>
-            <input> fcs/fly-by-wire/pitch/pitch-rate-second-path </input>
+            <input> fcs/fly-by-wire/pitch/normal-gain-path-final </input>
+            <input> fcs/fly-by-wire/pitch/pitch-rate-gain-path-final </input>
         </summer>
         
         <summer name="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-combined">
@@ -988,29 +1009,36 @@
             <input> fcs/fly-by-wire/pitch/pitch-rate-lower-gain </input>
             <input> fcs/fly-by-wire/pitch/n-and-pitch-rate-combined </input>
         </summer>
+		
+		<lag_filter name="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-lagged">
+			<description>
+				LJQC: Additional lag filter when MLG WOW
+			</description>
+            <input> fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-combined </input>
+            <c1> 17.2 </c1>
+        </lag_filter>
+		
+		<switch name="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-lag-switch">
+            <default value="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-combined"/>
+            <test logic="AND" value="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-lagged">
+                fcs/fly-by-wire/MLG-GND == 1
+            </test>
+        </switch>
 
         <lead_lag_filter name="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-lead-lagged">
-            <input> fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-combined </input>
+            <input> fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-lag-switch </input>
             <c1> 3 </c1>
             <c2> 12 </c2>
             <c3> 1 </c3>
             <c4> 12 </c4>
         </lead_lag_filter>
-        
-        <switch name="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-lead-lag-switch">
-            <default value="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-lead-lagged"/>
-            <test logic="AND" value="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-combined">
-                fcs/fly-by-wire/MLG-GND == 0
-                fcs/fly-by-wire/diagram1987 == 1
-            </test>
-        </switch>
-
+       
         <second_order_filter name="fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-demand">
             <description>
                 on old diagram looks to be 2.5, not 2 nor 25
                 DNU
             </description>
-            <input> fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-lead-lag-switch </input>
+            <input> fcs/fly-by-wire/pitch/alpha-and-n-and-pitch-rate-lead-lagged </input>
             <c1> 2.5 </c1>
             <c2> 20 </c2>
             <c3> 3500 </c3>
@@ -1428,39 +1456,15 @@
     
     
     <channel execrate="1" name="Roll">
-        
-        <fcs_function name="fcs/aileron-cmd-pow-norm">
-            <function>
-                    <ifthen>
-                        <lt>
-                            <p> fcs/aileron-cmd-norm </p>
-                            <v> 0 </v>
-                        </lt>
-                        <product>
-                            <v> -1 </v>
-                            <pow>
-                                <abs>
-                                    <p>fcs/aileron-cmd-norm</p>
-                                </abs>
-                                <v>1.3</v>
-                            </pow>
-                        </product>
-                        <pow>
-                            <p>fcs/aileron-cmd-norm</p>
-                            <v>1.3</v>
-                        </pow>
-                    </ifthen>
-            </function>
-        </fcs_function>
 
         <fcs_function name="fcs/fly-by-wire/roll/stick-force-lbf">
             <function>
                 <table>
-                    <independentVar lookup="row">fcs/aileron-cmd-pow-norm</independentVar>
+                    <independentVar lookup="row">fcs/aileron-cmd-norm</independentVar>
                     <tableData>
-                       -1 -17
+                       -1 -17.57
                         0   0
-                        1  17
+                        1  17.57
                     </tableData>
                 </table>
             </function>
@@ -1500,6 +1504,8 @@
             <description>
                 The -1 factor was removed since it was wrong. When more than
                 5 deg nosedown elev is commanded this comes into effect.
+				
+				LJQC: Should be more than 4.2 deg elev leading edge down. Todo: check.
             </description>
             <function>
                 <product>
@@ -1509,7 +1515,7 @@
                                 <p>fcs/fly-by-wire/pitch/integrator-final</p>
                                 <!--<v>-1</v>
                             </product>-->
-                            <v>-5</v>
+                            <v>-4.2</v>
                         </sum>
                         <v>0</v>
                     </max>
@@ -1517,22 +1523,33 @@
                 </product>
             </function>
         </fcs_function>
+		
+		<switch name="fcs/fly-by-wire/roll/bias-catiii">
+            <description>
+                LJQC: 136 deg/s cat-III bias added to roll rate limiter.
+            </description>
+            <default value="0"/>
+            <test logic="OR" value="136">
+                fcs/fly-by-wire/enable-cat-III == 1                
+            </test>
+        </switch>
 
         <summer name="fcs/fly-by-wire/roll/control-c/input-sum">
             <input>fcs/fly-by-wire/roll/control-c/pressure-input</input>
             <input>fcs/fly-by-wire/roll/control-c/alpha-input</input>
             <input>fcs/fly-by-wire/roll/control-c/elevator-cmd-input</input>
+			<input>fcs/fly-by-wire/roll/bias-catiii</input>
         </summer>
 
         <fcs_function name="fcs/fly-by-wire/roll/control-c/scheduled-gain-limited">
             <function>
                 <min>
-                    <v>228</v>
+                    <v>244</v>
                     <product>
                         <table>
                             <independentVar lookup="row">fcs/fly-by-wire/pitch/control-c/roll-rate-abs</independentVar>
                             <tableData>
-                                30 1 <!-- changed to 1 due to FG pilots use stick not pressure sticks -->
+                                30 1 <!-- not exist in 189675 -->
                                 50 1
                             </tableData>
                         </table>
@@ -1545,7 +1562,7 @@
         <fcs_function name="fcs/fly-by-wire/roll/control-c/max-cmd-roll-rate">
             <function>
                 <difference>
-                    <v>308</v>
+                    <v>324</v>
                     <p>fcs/fly-by-wire/roll/control-c/scheduled-gain-limited</p>
                 </difference>
             </function>
@@ -1556,7 +1573,7 @@
                 GR1F-16CJ-1 page 120
                 DBU - Maximum roll rate command is a constant 167 degrees per second.
             </description>
-            <default value="308"/>
+            <default value="324"/>
             <test logic="OR" value="fcs/fly-by-wire/roll/control-c/max-cmd-roll-rate">
                 fcs/fly-by-wire/control-c-actual == 1
             </test>
@@ -1566,7 +1583,7 @@
             <function>
                 <quotient>
                     <p>fcs/fly-by-wire/roll/max-cmd-roll-rate</p>
-                    <v>308</v>
+                    <v>324</v>
                 </quotient>
             </function>
         </fcs_function>
@@ -1577,15 +1594,15 @@
                 <table>
                     <independentVar lookup="row">fcs/fly-by-wire/roll/stick-force-lbf</independentVar>
                     <tableData>
-                         -17  -308 
-                         -11   -80 
-                          -6   -20  
-                          -1     0  
-                           0     0  
-                           1     0   
-                           6    20  
-                          11    80  
-                          17   308  
+                        -17.57  -324 
+                        -9      -80 
+                        -5      -20  
+                        -1      0  
+                        0       0  
+                        1       0   
+                        5       20  
+                        9       80  
+                        17.57   324  
                     </tableData>
                 </table>
                 <p>fcs/fly-by-wire/roll/min-cmd-roll-rate</p>
@@ -1611,7 +1628,7 @@
                         <independentVar lookup="row">fcs/fly-by-wire/roll/enable-cat-III</independentVar>
                         <tableData>
                              0  1
-                             1  0.6
+                             1  1
                         </tableData>
                     </table>
                     <!--<table>  this is already done in fcs/fly-by-wire/roll/gain-switch

--- a/Systems/jsb-controls.xml
+++ b/Systems/jsb-controls.xml
@@ -993,6 +993,7 @@
 		<pure_gain name="fcs/fly-by-wire/pitch/pitch-rate-cmd-gained">
 			<description>
 				LJQC: (AOA - 10)*0.305, take pos val, and adds to the pitch rate feedback path.
+				Check: 1G stall at 21 deg AOA according to 1F-16CJ-1.
             </description>
             <input>fcs/fly-by-wire/pitch/pitch-rate-cmd-sum</input>
             <gain> 0.305 </gain>


### PR DESCRIPTION
Hi,

I've integrated some changes from the ADA 189675 diagram to make the overall control characteristics more akin to T.O.  -1 manuals. Main changes are in the take-off & landing gains where pitch-rate feedback is employed instead of Nz feedback, starting from F-16A block 10, which is not present in ADA 055417. Now it is correctly implemented according to the graph.

Other minor changes are in CAT III, roll rate limiter, rudder authority limiter and stick command gradient.


What I haven't done:
Independent YF-16 control law, and differences between Analog and Digital FLCS control law. For example the max g limit of Analog FLCS is 9.3g, while it's 9.0g in DFLCS. There's also additional feedbacks employed in DFLCS to enhance spin resistance, like AOS and AOS rate feedback. Yaw rate limiter to provide anti-spin control at inverted spin, etc etc.

For YF-16, I believe there's a set of YF-16 control block diagram in the book: General Dynamics Case Study on the F-16 Fly-by-Wire Flight Control System.

Cheers.