### PR TITLE
Arms: fix aim-120 maddog bug

### DIFF
--- a/Nasal/missile-code.nas
+++ b/Nasal/missile-code.nas
@@ -3173,6 +3173,10 @@ var AIM = {
 		} else {
 			me.t_coord_sampled = me.t_coord;
 		}
+		if (me["t_coord_sampled"] == nil) {
+			# Without this, t_coord_sampled can possibly be undefined in maddog mode.
+			me.t_coord_sampled = me.t_coord;
+		}
 
 		# Calculate current target elevation and azimut deviation.
 		me.t_alt            = me.t_coord_sampled.alt()*M2FT;


### PR DESCRIPTION
This PR fixes a bug where missiles launched in maddog mode freeze mid-air due to an undefined attribute. This seems to have been caused by b13ffb3aef3138fbf6b457475bbe4ee76a4a9ca6.

Related:
- https://discord.com/channels/379782363061813248/496121096492417025/1090344903512440835
- https://discord.com/channels/379782363061813248/496121096492417025/1091361542374703115
- https://discord.com/channels/379782363061813248/496121096492417025/1098148782778089472