### PR TITLE
Model: Fix roll trim scroll direction animation

### DIFF
--- a/Models/Cockpit/Main/panels_mlu_left-console.xml
+++ b/Models/Cockpit/Main/panels_mlu_left-console.xml
@@ -1857,7 +1857,7 @@
         <drag-scale-px>2.5</drag-scale-px><!-- 10 is default -->
         <repeatable>true</repeatable>
         <interval-sec>0.5</interval-sec>
-        <factor>90</factor>
+        <factor>-90</factor>
         <center>
             <x-m>0.71282</x-m>   <!--  0.56569 + 0.14713  -->
             <y-m>-0.39609</y-m>  <!--  -0.35829 + -.0378  -->


### PR DESCRIPTION
The roll trim dial animation was backwards, and even though the dial functioned correctly the visual model appeared to be scrolling in the opposite direction. This PR corrects the animation direction. Fixes #516.