### PR TITLE
Added <expected-aircraft-dir-name> to remove issues with aircraft folder name

### DIFF
--- a/f16-base.xml
+++ b/f16-base.xml
@@ -14,6 +14,7 @@
     <sim>
         <aircraft-version>3.72</aircraft-version>
         <minimum-fg-version>2020.3</minimum-fg-version>
+	<expected-aircraft-dir-name>f16</expected-aircraft-dir-name>
         <!-- enable "parkpos=AVAILABLE" option for the F-16 -->
         <dimensions>
             <radius-m type="double">10.0</radius-m>


### PR DESCRIPTION
Example:
f16-master will display this:
![image](https://github.com/NikolaiVChr/f16/assets/72032903/2bb3b14b-d7ba-4cfb-a469-4b8a75404194)
