### PR TITLE
DED: CRUS mode select use M-SEL button

### DIFF
--- a/Nasal/HUD/HUD_main.nas
+++ b/Nasal/HUD/HUD_main.nas
@@ -1339,7 +1339,7 @@ append(obj.total, obj.speed_curr);
              func(hdp)
                                       {
                                         if (!hdp.getproper("dgft") and !hdp.getproper("gear_down")) {
-                                          if (ded.dataEntryDisplay.crusModeSelected == "TOS") {
+                                          if (getprop("f16/ded/cur-crus-mode") == "TOS") {
                                             var desired_kt = getprop("/f16/ded/crus-req-gs");
                                             if (desired_kt != nil) {
                                               obj.ias_desired.show();

--- a/Nasal/ded.nas
+++ b/Nasal/ded.nas
@@ -549,7 +549,7 @@ var dataEntryDisplay = {
         }
 
 
-        me.text[0] = sprintf("      CRUS  %s      %s ", tempCrusMode, tempNo);
+        me.text[0] = sprintf("      CRUS %s     %s ", tempCrusMode, tempNo);
 		# me.text[0] = sprintf("     CRUS  RNG  ",me.no);
 		if (crusMode == "TOS") {
 		    var time = getprop("/sim/time/gmt-string");

--- a/Nasal/ded.nas
+++ b/Nasal/ded.nas
@@ -18,7 +18,7 @@ var STPTlonFE = EditableLON.new("f16/ded/lon", convertDegreeToStringLon);
 var STPTnumFE = EditableField.new("f16/ded/stpt-edit", "%3d", 3);
 var STPTradFE = EditableField.new("f16/ded/stpt-rad", "%2d", 2);
 var STPTaltFE = EditableField.new("f16/ded/alt", "%5d", 5);
-var CRUSmodeTF = toggleableFieldTwo.new(["TOS", "RNG"], "f16/ded/crus-mode");
+var CRUSmodeTF = toggleableMode.new(["TOS", "RNG"], "f16/ded/crus-mode", "f16/ded/cur-crus-mode");
 var CRUSdesTosEF = EditableTime.new("f16/ded/crus-des-tos", steerpoints.getAbsoluteTOS);
 #var CRUSstptEF = EditableField.new("f16/ded/crus-stpt", "%3d", 3);
 var STPTtypeTF = toggleableField.new(["   ", " 2 ", " 5 ", " 6 ", " 11", " 20", " SH", " P ", " AAA"], "f16/ded/stpt-type");
@@ -526,23 +526,22 @@ var dataEntryDisplay = {
 		me.text[0] = sprintf("      STPT %s  AUTO %s", pSTPT.vector[0].getText(), me.no);
 	},
 
-    crusMode: "TOS",
-    crusModeSelected: nil,
 	updateCrus: func() {
 		# Source: F-16 A/B Mid-Life Update Production Tape M1: Pilot's guide to new to new capabilities & cockpit enhancements.
 		# This page does not yet support HOME or EDR
 
         # The top right STPT number should be hidden except on the TOS page
         var tempNo = "";
-        if (me.crusMode == "TOS") {
+        var crusMode = getprop("f16/ded/crus-mode");
+        var tempCrusMode = crusMode;
+        if (crusMode == "TOS") {
             tempNo = me.no;
         }
 
-        var tempCrusMode = me.crusMode;
         if (CRUSmodeTF.selected) {
             tempCrusMode = "*"~tempCrusMode~"*";
         }
-        if (me.crusModeSelected == me.crusMode) {
+        if (getprop("f16/ded/cur-crus-mode") == crusMode) {
             tempCrusMode = backgroundText(tempCrusMode);
         }
         if (!CRUSmodeTF.selected) {
@@ -552,7 +551,7 @@ var dataEntryDisplay = {
 
         me.text[0] = sprintf("      CRUS  %s      %s ", tempCrusMode, tempNo);
 		# me.text[0] = sprintf("     CRUS  RNG  ",me.no);
-		if (me.crusMode == "TOS") {
+		if (crusMode == "TOS") {
 		    var time = getprop("/sim/time/gmt-string");
 		    var cur_wp = steerpoints.getCurrent();
 		    var cur_des = steerpoints._getCurrentDesiredTOS();
@@ -591,7 +590,7 @@ var dataEntryDisplay = {
                 des_tos_last = 0;
             }
 
-		} elsif (me.crusMode == "RNG") {
+		} elsif (crusMode == "RNG") {
 		    # The steerpoint is currently fixed at last steerpoint, unless using a non route steerpoint
             var fuel   = "";
             var fp = flightplan();
@@ -1443,16 +1442,17 @@ setlistener("f16/avionics/rtn-seq", func() {
 		}
 
 		if (dataEntryDisplay.page == pCRUS and CRUSmodeTF.selected) {
-		    if (dataEntryDisplay.crusMode == "TOS") {
-				dataEntryDisplay.crusMode = "RNG";
+		    CRUSmodeTF.sequence();
+		    #if (dataEntryDisplay.crusMode == "TOS") {
+			#	dataEntryDisplay.crusMode = "RNG";
 			#} elsif (dataEntryDisplay.crusMode == "RNG") {
 			#	dataEntryDisplay.crusMode = "HOME";
 			#} elsif (dataEntryDisplay.crusMode == "HOME") {
 			#	dataEntryDisplay.crusMode = "EDR";
 			#} elsif (dataEntryDisplay.crusMode == "EDR") {
-			} else {
-				dataEntryDisplay.crusMode = "TOS";
-			}
+			#} else {
+			#	dataEntryDisplay.crusMode = "TOS";
+			#}
 		}
 
 		if (dataEntryDisplay.page == pMARK and dataEntryDisplay.markModeSelected) {

--- a/Nasal/dedFuncs.nas
+++ b/Nasal/dedFuncs.nas
@@ -258,9 +258,9 @@ var toggleableField = {
 	},
 };
 
-var toggleableFieldTwo = {
-	new: func(valuesVector, prop) {
-		var tF = {parents: [toggleableFieldTwo,StandardField]};
+var toggleableMode = {
+	new: func(valuesVector, prop, prop2) {
+		var tF = {parents: [toggleableMode,StandardField]};
 		tF.valuesVector = valuesVector;
 		tF.value = "";
 		tF.index = 0;
@@ -272,7 +272,9 @@ var toggleableFieldTwo = {
 		tF.recallStatus = 0;
 		tF.listener = nil;
 		tF.skipMe = 0;
+		tF.prop2 = prop2;
 		tF.init();
+		setprop(tF.prop, tF.valuesVector[tF.index]);
 		return tF;
 	},
 	init: func() {
@@ -291,7 +293,14 @@ var toggleableFieldTwo = {
 	},
 	append: func(letter) {
 		if (letter != "0") { return; }
-		me.index += 1;
+		if (getprop(me.prop2) != getprop(me.prop)) {
+            setprop(me.prop2, getprop(me.prop));
+        } else {
+            setprop(me.prop2, 0); # I'd rather nil but 0 works
+        }
+	},
+	sequence: func() {
+	    me.index += 1;
 		if (me.index >= size(me.valuesVector)) {
 			me.index = 0;
 		}
@@ -301,13 +310,7 @@ var toggleableFieldTwo = {
 		return;
 	},
 	enter: func() {
-	    # TODO: This should be done via the M-SEL mode select button, but I don't know how to implement that
-	    if (dataEntryDisplay.crusModeSelected != dataEntryDisplay.crusMode) {
-            dataEntryDisplay.crusModeSelected = dataEntryDisplay.crusMode;
-        } else {
-            dataEntryDisplay.crusModeSelected = nil;
-        }
-        return;
+	    return;
 	},
 	getText: func() {
 		if (me.selected) {


### PR DESCRIPTION
CRUS mode select now uses M-SEL button. Internally it now uses a better toggleableMode field which can be re-used in other pages as well. Also, fixes a display issue where the up/down arrows were cut off.