### PR TITLE
Sim: Fix spam - Don't print at end of flightplan

### DIFF
--- a/Nasal/flightPlanDelegate.nas
+++ b/Nasal/flightPlanDelegate.nas
@@ -269,7 +269,7 @@ var F16GPSDeleagte = {
             # standard leq sequencing
             var nextIndex = me.flightplan.current + 1;
             if (nextIndex >= me.flightplan.numWaypoints()) {
-                logprint(LOG_INFO, "default GPS sequencing, not finishing flightplan");
+                #logprint(LOG_INFO, "default GPS sequencing, not finishing flightplan");
                 #me.flightplan.finish();
             } elsif (me.flightplan.nextWP().wp_type == 'discontinuity') {
                 logprint(LOG_INFO, "default GPS sequencing DISCONTINUITY in flightplan, switching to OBS mode");


### PR DESCRIPTION
Somewhat recently a change was made where upon reaching the end of a flightplan, autopilot would orbit the last steerpoint instead of exiting the flightplan. However, a message was printed and since the flightplan is no longer exited, that message would flood the console output and render it impossible to see anything else. This PR removes that message to resolve the spam.