### PR TITLE
LX: Fix Procedural light artifacts affecting some gpu drivers

### DIFF
--- a/Models/Effects/lights/procedural-light-als-and-fixed-pipeline.eff
+++ b/Models/Effects/lights/procedural-light-als-and-fixed-pipeline.eff
@@ -94,7 +94,7 @@
         <fragment-shader>Shaders/light-ALS.frag</fragment-shader>
         <fragment-shader>Shaders/noise.frag</fragment-shader>
         <fragment-shader>Shaders/hazes.frag</fragment-shader>
-	<fragment-shader>Shaders/filters-ALS.frag</fragment-shader>
+	      <fragment-shader>Shaders/filters-ALS.frag</fragment-shader>
       </program>
 
     

--- a/Models/Effects/lights/procedural-light-als-and-fixed-pipeline.eff
+++ b/Models/Effects/lights/procedural-light-als-and-fixed-pipeline.eff
@@ -94,6 +94,7 @@
         <fragment-shader>Shaders/light-ALS.frag</fragment-shader>
         <fragment-shader>Shaders/noise.frag</fragment-shader>
         <fragment-shader>Shaders/hazes.frag</fragment-shader>
+	<fragment-shader>Shaders/filters-ALS.frag</fragment-shader>
       </program>
 
     


### PR DESCRIPTION
This PR merges in [fgaddon MR #58](https://gitlab.com/flightgear/fgdata/-/merge_requests/58). The shader affected is copied directly into this repo so it was not fixed when fgdata was updated.